### PR TITLE
TupletMarginLoss

### DIFF
--- a/configs/experiment/TupletMarginLoss.yaml
+++ b/configs/experiment/TupletMarginLoss.yaml
@@ -1,0 +1,16 @@
+loss:
+    name: TupletMarginLoss
+    margin: 5.73
+    scale: 64
+miner:
+    name: AngularMiner
+    angle: 20
+trainer:
+    batch_size: 64
+    loss_weights:
+        reconstruction_loss: 1.0
+        metric_loss: 1.0
+    num_epochs: 3
+optimizer:
+  lr: 0.01
+  name: Adam


### PR DESCRIPTION
Tuplet Margin losss는 miner가 필요하지 않음(Loss function에서 알아서 가중치를 줌)

batch size대로 tuplet을 만들기 때문에 batch size가 작음

epoch, optimizer lr 늘려서 다시 실험

<img width="446" alt="스크린샷 2020-08-16 오전 9 29 23" src="https://user-images.githubusercontent.com/23354017/90324293-bd7f7200-dfa7-11ea-9c03-3e96c0a8df51.png">
<img width="1267" alt="스크린샷 2020-08-16 오전 9 29 29" src="https://user-images.githubusercontent.com/23354017/90324294-c2dcbc80-dfa7-11ea-95f5-b3b703798ac2.png">
