### PR TITLE
Locality

### DIFF
--- a/tests/locality_test.py
+++ b/tests/locality_test.py
@@ -47,6 +47,8 @@ def single_lookup(seed_hash, dataset, output_path):
     seed_test_acc = dataset.query(
         api101.ModelSpec(matrix=seed_matrix, ops=seed_ops), 'test', epochs=108)
 
+    random.seed(seed_hash)
+
     row_dict = dict()
     hash_iterator = list(dataset.hash_iterator())
     random.shuffle(hash_iterator)


### PR DESCRIPTION
#21 

- Get `edit-distance=1,2,...,MAX_EDIT_DISTANCE` architecture from each seed architecture
  (`get_edit_distance` returns 0 if `nx.graph_edit_distance` returns `None`\
   `nx.graph_edit_distance` returns `None` if `calculated_edit_distance > upper_bound`)
- Save as csv
- Use multiprocessing to save time